### PR TITLE
Update jstz.js

### DIFF
--- a/jstz.js
+++ b/jstz.js
@@ -313,7 +313,7 @@
       '120,1'    : 'Asia/Beirut',
       '120,0'    : 'Africa/Johannesburg',
       '180,0'    : 'Asia/Baghdad',
-      '180,1'    : 'Europe/Moscow',
+      '180,0'    : 'Europe/Moscow',
       '210,1'    : 'Asia/Tehran',
       '240,0'    : 'Asia/Dubai',
       '240,1'    : 'Asia/Baku',


### PR DESCRIPTION
The timezone from Russia has been set to UTC+3 permanently on 26 October 2014.  This PR updates that

More info on the time-zone update:  [https://en.wikipedia.org/wiki/Moscow_Time](https://en.wikipedia.org/wiki/Moscow_Time)

> Moscow Time (Russian: Моско́вское вре́мя) is the time zone for the city of Moscow, Russia, and most of western Russia, including Saint Petersburg. It is the second-westernmost of the nine time zones of Russia. It has been set to UTC+3 permanently on 26 October 2014;[1] before that date it had been set to UTC+4 year-round since 27 March 2011.[2] 